### PR TITLE
restart watchdog on failure

### DIFF
--- a/roles/app/templates/zds-watchdog.service.j2
+++ b/roles/app/templates/zds-watchdog.service.j2
@@ -7,6 +7,8 @@ User=zds
 Group=zds
 ExecStart={{ workdir }}/wrapper publication_watchdog
 ExecStop=/bin/kill -s TERM $MAINPID
+Restart=on-failure
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Cette PR permet de redemarrer watchdog si le service tombe.