### PR TITLE
(LaTeX) Install alternative tabu package

### DIFF
--- a/roles/latex/tasks/packages.yml
+++ b/roles/latex/tasks/packages.yml
@@ -36,3 +36,17 @@
   when: installed_packages.content|b64decode|trim != latex_packages|join(" ")
   tags:
     - bootstrap
+
+- name: create tabu directory
+  file:
+    path: /opt/zds/texmf/tex/latex/tabu/
+    state: directory
+  tags:
+    - bootstrap
+
+- name: install tabu package
+  get_url:
+    url: https://raw.githubusercontent.com/tabu-issues-for-future-maintainer/tabu/master/tabu.sty
+    dest: /opt/zds/texmf/tex/latex/tabu/tabu.sty
+  tags:
+    - bootstrap

--- a/roles/latex/vars/main.yml
+++ b/roles/latex/vars/main.yml
@@ -15,7 +15,6 @@ latex_packages:
   - ntheorem
   - pagecolor
   - relsize
-  - tabu
   - varwidth
   - xpatch
   - xstring


### PR DESCRIPTION
Install alternative tabu package

To be merged after https://github.com/zestedesavoir/latex-template/pull/119.