### PR TITLE
Update ansible.cfg to avoid deprecation warnings

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,7 +1,8 @@
 [defaults]
 inventory = ./hosts
-allow_world_readable_tmpfiles = true
+#allow_world_readable_tmpfiles = true # to avoid deprecation warning (see https://docs.ansible.com/ansible/latest/reference_appendices/config.html#allow-world-readable-tmpfiles)
 stdout_callback = debug
+interpreter_python = auto # to avoid deprecation warning (see https://docs.ansible.com/ansible/2.10/reference_appendices/interpreter_discovery.html)
 
 [ssh_connection]
 pipelining = true


### PR DESCRIPTION
J'utilise Ansible 2.10.4 et il m'affiche quelques avertissements:
```
[DEPRECATION WARNING]: ALLOW_WORLD_READABLE_TMPFILES option, moved to a per plugin approach that is more flexible, use mostly the same config will work, but now controlled from the plugin itself and not using the general constant. 
instead. This feature will be removed from ansible-base in version 2.14. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: Distribution debian 10.7 on host scaleway.zestedesavoir.com should use /usr/bin/python3, but is using /usr/bin/python for backward compatibility with prior Ansible releases. A future Ansible release will default to
 using the discovered platform python for this host. See https://docs.ansible.com/ansible/2.10/reference_appendices/interpreter_discovery.html for more information. This feature will be removed in version 2.12. Deprecation warnings can 
be disabled by setting deprecation_warnings=False in ansible.cfg.
```

Ce commit adapte le fichier `ansible.cfg` pour résoudre ces avertissements. 

Pour le premier avertissement, je ne sais pas s'il faut remettre cette option quelque part (sous un _plugin_ comme c'est plutôt indiqué).