### PR TITLE
Supprime l'ajout des / finaux par nginx

### DIFF
--- a/roles/web/templates/nginx/sites-available/zestedesavoir.j2
+++ b/roles/web/templates/nginx/sites-available/zestedesavoir.j2
@@ -62,11 +62,6 @@ server {
             return 503;
         }
 
-        # Ajout d'un trailing slash sur les URLs
-        if ($uri !~ (\.|^/api)) {
-            rewrite ^(.*[^/])$ $1/ permanent;
-        }
-
         limit_req zone=remote_addr burst=10;
         limit_req zone=request_uri burst=20;
         limit_req_status 429;


### PR DESCRIPTION
Cet ajout était trop systématique, et est de toute façon Django le gère déjà. Plus important, cet ajout systématique cassait les nouvelles pages de profil.

Référence : zestedesavoir/zds-site#6057