### PR TITLE
Corrige la CI

### DIFF
--- a/roles/common/tasks/nodejs.yml
+++ b/roles/common/tasks/nodejs.yml
@@ -6,11 +6,8 @@
 - name: add Node.js repository
   ansible.builtin.apt_repository:
     filename: nodejs
-    repo: "{{ item }} https://deb.nodesource.com/node_12.x {{ ansible_distribution_release }} main"
+    repo: "deb https://deb.nodesource.com/node_12.x {{ ansible_distribution_release }} main"
     state: present
-  with_items:
-    - deb
-    - deb-src
 
 - name: add Node.js repository preferences
   ansible.builtin.template:

--- a/roles/common/tasks/nodejs.yml
+++ b/roles/common/tasks/nodejs.yml
@@ -1,7 +1,7 @@
 - name: add Node.js repository key
   ansible.builtin.apt_key:
     id: 9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280
-    keyserver: "pool.sks-keyservers.net"
+    keyserver: "hkp://keyserver.ubuntu.com:80"
 
 - name: add Node.js repository
   ansible.builtin.apt_repository:

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: add elasticsearch repository key
   ansible.builtin.apt_key:
     id: 46095ACC8548582C1A2699A9D27D666CD88E42B4
-    keyserver: "pool.sks-keyservers.net"
+    keyserver: "hkp://keyserver.ubuntu.com:80"
 
 - name: add elasticsearch repository
   ansible.builtin.apt_repository:

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: add mariadb repository key
   ansible.builtin.apt_key:
     id: 177F4010FE56CA3336300305F1656F24C74CD1D8
-    keyserver: "pool.sks-keyservers.net"
+    keyserver: "hkp://keyserver.ubuntu.com:80"
 
 - name: add mariadb repository
   ansible.builtin.apt_repository:

--- a/roles/web/tasks/main.yml
+++ b/roles/web/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: add nginx repository key
   ansible.builtin.apt_key:
     id: 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62
-    keyserver: "pool.sks-keyservers.net"
+    keyserver: "hkp://keyserver.ubuntu.com:80"
 
 - name: add nginx repository
   ansible.builtin.apt_repository:

--- a/roles/web/tasks/main.yml
+++ b/roles/web/tasks/main.yml
@@ -6,11 +6,8 @@
 - name: add nginx repository
   ansible.builtin.apt_repository:
     filename: nginx
-    repo: "{{ item }} https://nginx.org/packages/debian/ {{ ansible_distribution_release }} nginx"
+    repo: "deb https://nginx.org/packages/debian/ {{ ansible_distribution_release }} nginx"
     state: present
-  with_items:
-    - "deb"
-    - "deb-src"
   register: repo
 
 - name: install nginx


### PR DESCRIPTION
Corrige le serveur de clés pour que Ansible fonctionne. J'en profite au passage pour supprimer les dépôts `deb-src`, dont on ne se sert pas.