### PR TITLE
Utilise Python3 dans l'hôte pour Ansible

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/ansible-community/ansible-lint.git
-    rev: v5.0.7
+    rev: v5.3.2
     hooks:
       - id: ansible-lint
         files: \.(yaml|yml)$

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,5 @@
 [defaults]
-interpreter_python = /usr/bin/python
+interpreter_python = /usr/bin/python3
 inventory = ./hosts
 stdout_callback = debug
 

--- a/roles/app/tasks/main.yml
+++ b/roles/app/tasks/main.yml
@@ -3,7 +3,6 @@
 - name: install app dependencies
   ansible.builtin.apt:
     pkg:
-      - python3
       - python3-dev
       - python3-venv
       - python-setuptools

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -41,3 +41,10 @@
     pkg: apt-transport-https
     state: present
   when: not apt_https_transport.stat.exists
+
+- name: install basic Python packages
+  ansible.builtin.apt:
+    pkg:
+      - python3
+      - python3-pip
+    state: present

--- a/roles/latex/tasks/main.yml
+++ b/roles/latex/tasks/main.yml
@@ -13,6 +13,13 @@
   tags:
     - bootstrap
 
+- name: install pygments
+  pip:
+    name: Pygments
+    executable: pip3
+  tags:
+    - bootstrap
+
 - include_tasks: packages.yml
   tags:
     - bootstrap

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -15,6 +15,7 @@
     pkg:
       - mariadb-server
       - mariadb-backup
+      - libmariadb-dev  # pour le paquet Python mysqlclient
     cache_valid_time: 3600
 
 - name: copy mariadb config files
@@ -31,8 +32,9 @@
     enabled: true
 
 - name: install MySQLdb-python
-  ansible.builtin.apt:
-    name: python-mysqldb
+  pip:
+    name: mysqlclient
+    executable: pip3
 
 - name: create mysql database
   community.mysql.mysql_db:


### PR DESCRIPTION
Fix #45

Je me suis rendu compte que résoudre cette issue pour simplifier la PR #50 pour le passage à Debian 11 (bien-sûr, je m'en suis rendu compte après avoir fini la PR pour Debian 11 ! :stuck_out_tongue: )

@Situphen une raison particulière pour avoir proposé PyMySQL ? mysqlclient semble [encore actif](https://github.com/PyMySQL/mysqlclient) et fonctionne avec Python 3. De plus, PyMySQL [ne fonctionne pas bien](https://github.com/ansible-collections/community.mysql/issues/212) dans Ansible... J'attends de voir leur réponse, s'il y a une solution qui va bien, on peut passer à PyMySQL.

J'en ai aussi profité pour installer Pygments via pip, puisque la transition vers Python 3/ Debian 11 demandait de changer le nom du paquet installé avec apt. Installé avec pip, le nom du paquet restera toujours le même.

