### PR TITLE
Passage à Debian 13

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 Vagrant.require_version ">= 1.7.0"
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "generic/debian12"
+  config.vm.box = "generic/debian13"
 
   config.vm.define 'zds-site' do |zds|
     zds.vm.network "forwarded_port", guest: 80, host: 8080

--- a/kitchen-matomo.yml
+++ b/kitchen-matomo.yml
@@ -2,7 +2,7 @@
 driver:
   name: docker
   privileged: true
-  run_command: /bin/systemd
+  run_command: /sbin/init
   require_chef_omnibus: false
   cap_add:
     - SYS_ADMIN
@@ -17,7 +17,7 @@ provisioner:
   additional_copy_path: requirements.yml
 
 platforms:
-  - name: debian-12
+  - name: debian-13
 
 suites:
   - name: default

--- a/kitchen-zds.yml
+++ b/kitchen-zds.yml
@@ -2,7 +2,7 @@
 driver:
   name: docker
   privileged: true
-  run_command: /bin/systemd
+  run_command: /sbin/init
   require_chef_omnibus: false
   cap_add:
     - SYS_ADMIN
@@ -17,7 +17,7 @@ provisioner:
   additional_copy_path: requirements.yml
 
 platforms:
-  - name: debian-12
+  - name: debian-13
 
 suites:
   - name: default


### PR DESCRIPTION
Pas encore fonctionnel : 
- la box Vagrant n'existe pas encore
- zds-site ne fonctionne pas encore avec Python 3.13 : https://github.com/zestedesavoir/zds-site/pull/6738#issuecomment-3218164111